### PR TITLE
Make maven work on OS X and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+.idea/
+kafka-connect-salesforce.iml

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
                     <descriptors>
                         <descriptor>src/main/assembly/package.xml</descriptor>
                     </descriptors>
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
I was unable to build without the <tarLongFileMode> configuration option, it appears from Stackoverflow this is a fairly common issue for the assembly plugin.