### PR TITLE
Fixed build errors and added support for pattern replacement to append event details like event type - created, updated, deleted in kafka topic name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
+        <!-- <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.2.3</version>
-        </dependency>
+        </dependency> -->
     </dependencies>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.2.3</version>
-        </dependency> -->
     </dependencies>
 </project>
 

--- a/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SObjectHelper.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SObjectHelper.java
@@ -45,9 +45,11 @@ class SObjectHelper {
   private static final Logger log = LoggerFactory.getLogger(SObjectHelper.class);
   private static final String TOPIC_NAME_SPLIT_REGEX = "(?=[^\\}]*(?:\\{|$))";
   private static final int ONE = 1;
+  private static final int TWO = 2;
   private static final String ESCAPE_CHAR = "\\";
   private static final String DOT = ".";
   private static final String HYPHEN = "-";
+  private static final String DOLLAR = "$";
 
   static {
     Parser p = new Parser();
@@ -221,8 +223,8 @@ class SObjectHelper {
     StringBuilder kafkaTopicNameBuilder = new StringBuilder();
     int idx = 0;
     for (String token : kafkaTopicSplit) {
-      if (token.startsWith("{") && token.endsWith("}")) {
-        replaceText(dataNode, kafkaTopicNameBuilder, token);  // e.g. token = {event.type}
+      if (token.startsWith(DOLLAR)) {
+        replaceText(dataNode, kafkaTopicNameBuilder, token);  // e.g. token = ${event.type}
       } else {
         kafkaTopicNameBuilder.append(token);
       }
@@ -235,7 +237,7 @@ class SObjectHelper {
   }
 
   private static void replaceText(JsonNode dataNode, StringBuilder kafkaTopicNameBuilder, String token) {
-    String path = token.substring(ONE, token.length() - ONE); // path = event.type
+    String path = token.substring(TWO, token.length() - ONE); // path = event.type
     JsonNode value = readValue(dataNode, path);
     if (value instanceof TextNode) {
       kafkaTopicNameBuilder.append(value.asText());

--- a/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceConfig.java
@@ -15,13 +15,14 @@
  */
 package com.github.jcustenborder.kafka.connect.salesforce;
 
-import io.confluent.kafka.connect.utils.config.ValidPattern;
+import java.util.Map;
+
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 
-import java.util.Map;
+import com.github.jcustenborder.kafka.connect.utils.config.ValidPattern;
 
 
 public class SalesforceSourceConfig extends AbstractConfig {
@@ -45,6 +46,7 @@ public class SalesforceSourceConfig extends AbstractConfig {
   public static final String KAFKA_TOPIC_CONF = "kafka.topic";
 
   public static final String CONNECTION_TIMEOUT_CONF = "connection.timeout";
+  public static final String TOPIC_NAME_DELIMITER = "topic.name.delimiter";
 
   static final String VERSION_DOC = "The version of the salesforce API to use.";
   static final String USERNAME_DOC = "Salesforce username to connect with.";
@@ -64,7 +66,8 @@ public class SalesforceSourceConfig extends AbstractConfig {
   static final String SALESFORCE_PUSH_TOPIC_NOTIFY_UNDELETE_DOC = "Flag to determine if the PushTopic should respond to undeletes.";
   static final String SALESFORCE_OBJECT_DOC = "The Salesforce object to create a topic for.";
   static final String KAFKA_TOPIC_DOC = "The Kafka topic to write the SalesForce data to.";
-
+  static final String TOPIC_NAME_DELIMITER_DOC = "The kafka topic delimiter. Default is . (DOT). Required when using string pattern replacement to read parameters from received data object and replace in kafka topic name.";
+  
   public SalesforceSourceConfig(ConfigDef config, Map<String, ?> parsedConfig) {
     super(config, parsedConfig);
   }
@@ -91,7 +94,8 @@ public class SalesforceSourceConfig extends AbstractConfig {
         .define(SALESFORCE_PUSH_TOPIC_NOTIFY_CREATE_CONF, Type.BOOLEAN, true, Importance.LOW, SALESFORCE_PUSH_TOPIC_NOTIFY_CREATE_DOC)
         .define(SALESFORCE_PUSH_TOPIC_NOTIFY_UPDATE_CONF, Type.BOOLEAN, true, Importance.LOW, SALESFORCE_PUSH_TOPIC_NOTIFY_UPDATE_DOC)
         .define(SALESFORCE_PUSH_TOPIC_NOTIFY_DELETE_CONF, Type.BOOLEAN, true, Importance.LOW, SALESFORCE_PUSH_TOPIC_NOTIFY_DELETE_DOC)
-        .define(SALESFORCE_PUSH_TOPIC_NOTIFY_UNDELETE_CONF, Type.BOOLEAN, true, Importance.LOW, SALESFORCE_PUSH_TOPIC_NOTIFY_UNDELETE_DOC);
+        .define(SALESFORCE_PUSH_TOPIC_NOTIFY_UNDELETE_CONF, Type.BOOLEAN, true, Importance.LOW, SALESFORCE_PUSH_TOPIC_NOTIFY_UNDELETE_DOC)
+        .define(TOPIC_NAME_DELIMITER, Type.STRING, ".", Importance.LOW, TOPIC_NAME_DELIMITER_DOC);
   }
 
   public String username() {
@@ -161,5 +165,9 @@ public class SalesforceSourceConfig extends AbstractConfig {
 
   public String version() {
     return this.getString(VERSION_CONF);
+  }
+
+  public String topicNameDelimiter() {
+    return this.getString(TOPIC_NAME_DELIMITER);
   }
 }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
@@ -207,7 +207,7 @@ public class SalesforceSourceTask extends SourceTask implements ClientSessionCha
         log.debug("message={}", jsonMessage);
       }
       JsonNode jsonNode = objectMapper.readTree(jsonMessage);
-      SourceRecord record = SObjectHelper.convert(jsonNode, this.config.salesForcePushTopicName(), this.config.kafkaTopic(), keySchema, valueSchema);
+      SourceRecord record = SObjectHelper.convert(this.config, jsonNode, keySchema, valueSchema);
       this.messageQueue.add(record);
     } catch (Exception ex) {
       if (log.isErrorEnabled()) {

--- a/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
@@ -46,7 +46,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 
 public class SalesforceSourceTask extends SourceTask implements ClientSessionChannel.MessageListener {
@@ -63,7 +62,7 @@ public class SalesforceSourceTask extends SourceTask implements ClientSessionCha
   Schema keySchema;
   Schema valueSchema;
   ObjectMapper objectMapper = new ObjectMapper();
-  AtomicBoolean connected = new AtomicBoolean(true);
+  boolean connected = true;
 
   @Override
   public String version() {
@@ -95,8 +94,8 @@ public class SalesforceSourceTask extends SourceTask implements ClientSessionCha
     return new BayeuxClient(this.streamingUrl.toString(), transport) {
       @Override
       public void onFailure(Throwable failure, List<? extends Message> messages) {
-        log.error("Connection failure");
-        connected.set(false);
+        log.debug("Connection failure");
+        connected = false;
       }
     };
   }
@@ -158,9 +157,9 @@ public class SalesforceSourceTask extends SourceTask implements ClientSessionCha
           if (log.isErrorEnabled()) {
             log.error("Error during handshake: {} {}", message.get("error"), message.get("exception"));
           }
-        } else if (!connected.get()) {
+        } else if (!connected) {
           subscribe();
-          connected.set(true);
+          connected = true;
         }
       }
     });

--- a/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
@@ -62,7 +62,7 @@ public class SalesforceSourceTask extends SourceTask implements ClientSessionCha
   Schema keySchema;
   Schema valueSchema;
   ObjectMapper objectMapper = new ObjectMapper();
-  boolean connected = true;
+  boolean isSubscribed = true;
 
   @Override
   public String version() {
@@ -95,7 +95,7 @@ public class SalesforceSourceTask extends SourceTask implements ClientSessionCha
       @Override
       public void onFailure(Throwable failure, List<? extends Message> messages) {
         log.debug("Connection failure");
-        connected = false;
+        isSubscribed = false;
       }
     };
   }
@@ -157,9 +157,9 @@ public class SalesforceSourceTask extends SourceTask implements ClientSessionCha
           if (log.isErrorEnabled()) {
             log.error("Error during handshake: {} {}", message.get("error"), message.get("exception"));
           }
-        } else if (!connected) {
+        } else if (!isSubscribed) {
           subscribe();
-          connected = true;
+          isSubscribed = true;
         }
       }
     });

--- a/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
@@ -160,6 +160,7 @@ public class SalesforceSourceTask extends SourceTask implements ClientSessionCha
           }
         } else if (!connected.get()) {
           subscribe();
+          connected.set(true);
         }
       }
     });

--- a/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
@@ -162,7 +162,7 @@ public class SalesforceSourceTask extends SourceTask implements ClientSessionCha
     this.streamingClient.handshake();
   }
 
-  public void subscribe() {
+  private void subscribe() {
     String channel = String.format("/topic/%s", this.config.salesForcePushTopicName());
     if (log.isInfoEnabled()) {
       log.info("Subscribing to {}", channel);

--- a/src/test/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceConfigTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceConfigTest.java
@@ -16,8 +16,9 @@
 package com.github.jcustenborder.kafka.connect.salesforce;
 
 
-import io.confluent.kafka.connect.utils.config.MarkdownFormatter;
 import org.junit.jupiter.api.Test;
+
+import com.github.jcustenborder.kafka.connect.utils.config.MarkdownFormatter;
 
 public class SalesforceSourceConfigTest {
 


### PR DESCRIPTION
@jcustenborder 
Summary of changes :

1. Modified the connector to support a configuration to include the salesforce notification event type as part of the topic name pattern being written to.
Few examples of kafka topic name with pattern -
kafka.topic=test1.test2.${event.type}
kafka.topic=test1-test2-${event.type}
kafka.topic=test1_test2_${event.type}

Also, added a config parameter to specify kafka topic name delimiter.
Property name is "topic.name.delimiter". Default value is DOT (.)

2. Fix for build error : io.confluent.kafka.connect.utils.* package does not exist. Changed imports to com.github.jcustenborder.kafka.connect.utils.*

3. Removed jackson databind 2.2.3 dependency because a version of jackson-databind (2.6.3) provided by connect-utils 0.2.53 dependency conflicts with 2.2.3 and throws NoSuchMethodError when invoking kafka connect REST API at http://localhost:8083/connectors
Exception : 
Caused by: java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.ObjectWriter.forType(Lcom/fasterxml/jackson/databind/JavaType;)Lcom/fasterxml/jackson/databind/ObjectWriter;

4. Fix for auto-subscribe issue mentioned [here](https://github.com/jcustenborder/kafka-connect-salesforce/issues/5)
