### PR TITLE
Fixes #35 - Return null if records are empty, so connect can pause

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
@@ -200,7 +200,13 @@ public class SalesforceSourceTask extends SourceTask {
 
     }
 
-    return records;
+    if (records.isEmpty()) {
+      // https://kafka.apache.org/11/javadoc/org/apache/kafka/connect/source/SourceTask.html#poll--
+      // docs say we should return null if there are no records, so that it will pause (not convinced need to)
+      return null;
+    } else {
+      return records;
+    }
   }
 
   @Override


### PR DESCRIPTION
Docs claim you should return null to allow the task to pause, not an
empty collection.
https://kafka.apache.org/11/javadoc/org/apache/kafka/connect/source/SourceTask.html#poll--